### PR TITLE
Added working directory property

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ NOTE: I suggest using a specific configuration for testing in the CI environment
 
 - `testcommand`: Required. The command to run your tests, do not include "npm" it is already included. The importance of this is so that any configuration options can be used. My suggestion is to create a configuration that uses 
 - `mocha`: Not required. 
+- `working_directory`: Optional. Directory to run the tests from (for when your angular project resides in a subdirectory) 
 
 ## License
 Scripts and documentation in this project are released under the MIT license.

--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,9 @@ inputs:
   mocha:
     description: Set to true in order to run mocha tests. This option will install mocha on the image.
     required: false
+  working-dir:
+    description: Working directory to execute the workflow in
+    required: false
 runs:
   using: docker
   image: Dockerfile

--- a/action.yml
+++ b/action.yml
@@ -11,7 +11,7 @@ inputs:
   mocha:
     description: Set to true in order to run mocha tests. This option will install mocha on the image.
     required: false
-  working-dir:
+  working-directory:
     description: Working directory to execute the workflow in
     required: false
 runs:

--- a/action.yml
+++ b/action.yml
@@ -11,7 +11,7 @@ inputs:
   mocha:
     description: Set to true in order to run mocha tests. This option will install mocha on the image.
     required: false
-  working-directory:
+  working_directory:
     description: Working directory to execute the workflow in
     required: false
 runs:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,7 +2,7 @@
 
 testcommand="$INPUT_TESTCOMMAND"
 mocha="$INPUT_MOCHA"
-working_dir="${INPUT_WORKING_DIRECTORY}"
+working_dir="$INPUT_WORKING_DIRECTORY"
 
 if [ -n "$working_dir" ]; then
     cd $working_dir

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,7 +2,7 @@
 
 testcommand="$INPUT_TESTCOMMAND"
 mocha="$INPUT_MOCHA"
-working_dir="${INPUT_WORKING_DIR}"
+working_dir="${INPUT_WORKING_DIRECTORY}"
 
 if [ -n "$working_dir" ]; then
     cd $working_dir

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,6 +2,11 @@
 
 testcommand="$INPUT_TESTCOMMAND"
 mocha="$INPUT_MOCHA"
+working_dir="${INPUT_WORKING_DIR}"
+
+if [ -n "$working_dir" ]; then
+    cd $working_dir
+fi
 
 echo "\n**Auditing Packages**\n"
 npm audit


### PR DESCRIPTION
As GitHub Actions does not support the `working-directory` directive on docker steps, I have added as property to the action to allow for this.
This way it is possible to also test on projects where the angular project resides inside of a sub-directory

closes #1 